### PR TITLE
VOUCHEDSEC-3967 - VOUCHEDSEC-3967-ios-webview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# OS X
+.DS_Store
+
+# Xcode
+build/
+*.xcconfig
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+*.xccheckout
+*.xcconfig
+profile
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+
+# models
+inference_graph.tflite
+labelmap_mobilenet_card.txt
+
+# Bundler
+.bundle
+
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build
+
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
+# 
+# Note: if you ignore the Pods directory, make sure to uncomment
+# `pod install` in .travis.yml
+#
+Pods/
+Podfile.lock

--- a/iOSVouchedWebview.xcodeproj/project.pbxproj
+++ b/iOSVouchedWebview.xcodeproj/project.pbxproj
@@ -1,0 +1,613 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 55;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		ECEBBC5B280E3835005F9BCC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBBC5A280E3835005F9BCC /* AppDelegate.swift */; };
+		ECEBBC5D280E3835005F9BCC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBBC5C280E3835005F9BCC /* SceneDelegate.swift */; };
+		ECEBBC5F280E3835005F9BCC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBBC5E280E3835005F9BCC /* ViewController.swift */; };
+		ECEBBC62280E3835005F9BCC /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ECEBBC60280E3835005F9BCC /* Main.storyboard */; };
+		ECEBBC64280E3837005F9BCC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = ECEBBC63280E3837005F9BCC /* Assets.xcassets */; };
+		ECEBBC67280E3837005F9BCC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = ECEBBC65280E3837005F9BCC /* LaunchScreen.storyboard */; };
+		ECEBBC72280E3837005F9BCC /* iOSVouchedWebviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBBC71280E3837005F9BCC /* iOSVouchedWebviewTests.swift */; };
+		ECEBBC7C280E3837005F9BCC /* iOSVouchedWebviewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBBC7B280E3837005F9BCC /* iOSVouchedWebviewUITests.swift */; };
+		ECEBBC7E280E3837005F9BCC /* iOSVouchedWebviewUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBBC7D280E3837005F9BCC /* iOSVouchedWebviewUITestsLaunchTests.swift */; };
+		ECEBBC8B280E39F6005F9BCC /* camera.js in Resources */ = {isa = PBXBuildFile; fileRef = ECEBBC8A280E39F6005F9BCC /* camera.js */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		ECEBBC6E280E3837005F9BCC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ECEBBC4F280E3835005F9BCC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECEBBC56280E3835005F9BCC;
+			remoteInfo = iOSVouchedWebview;
+		};
+		ECEBBC78280E3837005F9BCC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ECEBBC4F280E3835005F9BCC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ECEBBC56280E3835005F9BCC;
+			remoteInfo = iOSVouchedWebview;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		ECEBBC57280E3835005F9BCC /* iOSVouchedWebview.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSVouchedWebview.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECEBBC5A280E3835005F9BCC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		ECEBBC5C280E3835005F9BCC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		ECEBBC5E280E3835005F9BCC /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		ECEBBC61280E3835005F9BCC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		ECEBBC63280E3837005F9BCC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		ECEBBC66280E3837005F9BCC /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		ECEBBC68280E3837005F9BCC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		ECEBBC6D280E3837005F9BCC /* iOSVouchedWebviewTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSVouchedWebviewTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECEBBC71280E3837005F9BCC /* iOSVouchedWebviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSVouchedWebviewTests.swift; sourceTree = "<group>"; };
+		ECEBBC77280E3837005F9BCC /* iOSVouchedWebviewUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iOSVouchedWebviewUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		ECEBBC7B280E3837005F9BCC /* iOSVouchedWebviewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSVouchedWebviewUITests.swift; sourceTree = "<group>"; };
+		ECEBBC7D280E3837005F9BCC /* iOSVouchedWebviewUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSVouchedWebviewUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		ECEBBC8A280E39F6005F9BCC /* camera.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = camera.js; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		ECEBBC54280E3835005F9BCC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECEBBC6A280E3837005F9BCC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECEBBC74280E3837005F9BCC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		ECEBBC4E280E3835005F9BCC = {
+			isa = PBXGroup;
+			children = (
+				ECEBBC59280E3835005F9BCC /* iOSVouchedWebview */,
+				ECEBBC70280E3837005F9BCC /* iOSVouchedWebviewTests */,
+				ECEBBC7A280E3837005F9BCC /* iOSVouchedWebviewUITests */,
+				ECEBBC58280E3835005F9BCC /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		ECEBBC58280E3835005F9BCC /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				ECEBBC57280E3835005F9BCC /* iOSVouchedWebview.app */,
+				ECEBBC6D280E3837005F9BCC /* iOSVouchedWebviewTests.xctest */,
+				ECEBBC77280E3837005F9BCC /* iOSVouchedWebviewUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		ECEBBC59280E3835005F9BCC /* iOSVouchedWebview */ = {
+			isa = PBXGroup;
+			children = (
+				ECEBBC5A280E3835005F9BCC /* AppDelegate.swift */,
+				ECEBBC5C280E3835005F9BCC /* SceneDelegate.swift */,
+				ECEBBC5E280E3835005F9BCC /* ViewController.swift */,
+				ECEBBC60280E3835005F9BCC /* Main.storyboard */,
+				ECEBBC63280E3837005F9BCC /* Assets.xcassets */,
+				ECEBBC65280E3837005F9BCC /* LaunchScreen.storyboard */,
+				ECEBBC68280E3837005F9BCC /* Info.plist */,
+				ECEBBC8A280E39F6005F9BCC /* camera.js */,
+			);
+			path = iOSVouchedWebview;
+			sourceTree = "<group>";
+		};
+		ECEBBC70280E3837005F9BCC /* iOSVouchedWebviewTests */ = {
+			isa = PBXGroup;
+			children = (
+				ECEBBC71280E3837005F9BCC /* iOSVouchedWebviewTests.swift */,
+			);
+			path = iOSVouchedWebviewTests;
+			sourceTree = "<group>";
+		};
+		ECEBBC7A280E3837005F9BCC /* iOSVouchedWebviewUITests */ = {
+			isa = PBXGroup;
+			children = (
+				ECEBBC7B280E3837005F9BCC /* iOSVouchedWebviewUITests.swift */,
+				ECEBBC7D280E3837005F9BCC /* iOSVouchedWebviewUITestsLaunchTests.swift */,
+			);
+			path = iOSVouchedWebviewUITests;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		ECEBBC56280E3835005F9BCC /* iOSVouchedWebview */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ECEBBC81280E3837005F9BCC /* Build configuration list for PBXNativeTarget "iOSVouchedWebview" */;
+			buildPhases = (
+				ECEBBC53280E3835005F9BCC /* Sources */,
+				ECEBBC54280E3835005F9BCC /* Frameworks */,
+				ECEBBC55280E3835005F9BCC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iOSVouchedWebview;
+			productName = iOSVouchedWebview;
+			productReference = ECEBBC57280E3835005F9BCC /* iOSVouchedWebview.app */;
+			productType = "com.apple.product-type.application";
+		};
+		ECEBBC6C280E3837005F9BCC /* iOSVouchedWebviewTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ECEBBC84280E3837005F9BCC /* Build configuration list for PBXNativeTarget "iOSVouchedWebviewTests" */;
+			buildPhases = (
+				ECEBBC69280E3837005F9BCC /* Sources */,
+				ECEBBC6A280E3837005F9BCC /* Frameworks */,
+				ECEBBC6B280E3837005F9BCC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				ECEBBC6F280E3837005F9BCC /* PBXTargetDependency */,
+			);
+			name = iOSVouchedWebviewTests;
+			productName = iOSVouchedWebviewTests;
+			productReference = ECEBBC6D280E3837005F9BCC /* iOSVouchedWebviewTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		ECEBBC76280E3837005F9BCC /* iOSVouchedWebviewUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = ECEBBC87280E3837005F9BCC /* Build configuration list for PBXNativeTarget "iOSVouchedWebviewUITests" */;
+			buildPhases = (
+				ECEBBC73280E3837005F9BCC /* Sources */,
+				ECEBBC74280E3837005F9BCC /* Frameworks */,
+				ECEBBC75280E3837005F9BCC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				ECEBBC79280E3837005F9BCC /* PBXTargetDependency */,
+			);
+			name = iOSVouchedWebviewUITests;
+			productName = iOSVouchedWebviewUITests;
+			productReference = ECEBBC77280E3837005F9BCC /* iOSVouchedWebviewUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		ECEBBC4F280E3835005F9BCC /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1320;
+				LastUpgradeCheck = 1320;
+				TargetAttributes = {
+					ECEBBC56280E3835005F9BCC = {
+						CreatedOnToolsVersion = 13.2.1;
+					};
+					ECEBBC6C280E3837005F9BCC = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = ECEBBC56280E3835005F9BCC;
+					};
+					ECEBBC76280E3837005F9BCC = {
+						CreatedOnToolsVersion = 13.2.1;
+						TestTargetID = ECEBBC56280E3835005F9BCC;
+					};
+				};
+			};
+			buildConfigurationList = ECEBBC52280E3835005F9BCC /* Build configuration list for PBXProject "iOSVouchedWebview" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = ECEBBC4E280E3835005F9BCC;
+			productRefGroup = ECEBBC58280E3835005F9BCC /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				ECEBBC56280E3835005F9BCC /* iOSVouchedWebview */,
+				ECEBBC6C280E3837005F9BCC /* iOSVouchedWebviewTests */,
+				ECEBBC76280E3837005F9BCC /* iOSVouchedWebviewUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		ECEBBC55280E3835005F9BCC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECEBBC67280E3837005F9BCC /* LaunchScreen.storyboard in Resources */,
+				ECEBBC8B280E39F6005F9BCC /* camera.js in Resources */,
+				ECEBBC64280E3837005F9BCC /* Assets.xcassets in Resources */,
+				ECEBBC62280E3835005F9BCC /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECEBBC6B280E3837005F9BCC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECEBBC75280E3837005F9BCC /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		ECEBBC53280E3835005F9BCC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECEBBC5F280E3835005F9BCC /* ViewController.swift in Sources */,
+				ECEBBC5B280E3835005F9BCC /* AppDelegate.swift in Sources */,
+				ECEBBC5D280E3835005F9BCC /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECEBBC69280E3837005F9BCC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECEBBC72280E3837005F9BCC /* iOSVouchedWebviewTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		ECEBBC73280E3837005F9BCC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				ECEBBC7C280E3837005F9BCC /* iOSVouchedWebviewUITests.swift in Sources */,
+				ECEBBC7E280E3837005F9BCC /* iOSVouchedWebviewUITestsLaunchTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		ECEBBC6F280E3837005F9BCC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = ECEBBC56280E3835005F9BCC /* iOSVouchedWebview */;
+			targetProxy = ECEBBC6E280E3837005F9BCC /* PBXContainerItemProxy */;
+		};
+		ECEBBC79280E3837005F9BCC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = ECEBBC56280E3835005F9BCC /* iOSVouchedWebview */;
+			targetProxy = ECEBBC78280E3837005F9BCC /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		ECEBBC60280E3835005F9BCC /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				ECEBBC61280E3835005F9BCC /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		ECEBBC65280E3837005F9BCC /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				ECEBBC66280E3837005F9BCC /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		ECEBBC7F280E3837005F9BCC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		ECEBBC80280E3837005F9BCC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		ECEBBC82280E3837005F9BCC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7PKK3DW985;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iOSVouchedWebview/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = id.vouched.ios.iOSVouchedWebview;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		ECEBBC83280E3837005F9BCC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7PKK3DW985;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = iOSVouchedWebview/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = id.vouched.ios.iOSVouchedWebview;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		ECEBBC85280E3837005F9BCC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7PKK3DW985;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = id.vouched.ios.iOSVouchedWebviewTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOSVouchedWebview.app/iOSVouchedWebview";
+			};
+			name = Debug;
+		};
+		ECEBBC86280E3837005F9BCC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7PKK3DW985;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = id.vouched.ios.iOSVouchedWebviewTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOSVouchedWebview.app/iOSVouchedWebview";
+			};
+			name = Release;
+		};
+		ECEBBC88280E3837005F9BCC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7PKK3DW985;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = id.vouched.ios.iOSVouchedWebviewUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = iOSVouchedWebview;
+			};
+			name = Debug;
+		};
+		ECEBBC89280E3837005F9BCC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 7PKK3DW985;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = id.vouched.ios.iOSVouchedWebviewUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = iOSVouchedWebview;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		ECEBBC52280E3835005F9BCC /* Build configuration list for PBXProject "iOSVouchedWebview" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ECEBBC7F280E3837005F9BCC /* Debug */,
+				ECEBBC80280E3837005F9BCC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ECEBBC81280E3837005F9BCC /* Build configuration list for PBXNativeTarget "iOSVouchedWebview" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ECEBBC82280E3837005F9BCC /* Debug */,
+				ECEBBC83280E3837005F9BCC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ECEBBC84280E3837005F9BCC /* Build configuration list for PBXNativeTarget "iOSVouchedWebviewTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ECEBBC85280E3837005F9BCC /* Debug */,
+				ECEBBC86280E3837005F9BCC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		ECEBBC87280E3837005F9BCC /* Build configuration list for PBXNativeTarget "iOSVouchedWebviewUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				ECEBBC88280E3837005F9BCC /* Debug */,
+				ECEBBC89280E3837005F9BCC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = ECEBBC4F280E3835005F9BCC /* Project object */;
+}

--- a/iOSVouchedWebview.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/iOSVouchedWebview.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/iOSVouchedWebview.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/iOSVouchedWebview.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/iOSVouchedWebview/AppDelegate.swift
+++ b/iOSVouchedWebview/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  iOSVouchedWebview
+//
+//  Created by Jay Lorenzo on 4/18/22.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/iOSVouchedWebview/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/iOSVouchedWebview/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOSVouchedWebview/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/iOSVouchedWebview/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOSVouchedWebview/Assets.xcassets/Contents.json
+++ b/iOSVouchedWebview/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iOSVouchedWebview/Base.lproj/LaunchScreen.storyboard
+++ b/iOSVouchedWebview/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/iOSVouchedWebview/Base.lproj/Main.storyboard
+++ b/iOSVouchedWebview/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/iOSVouchedWebview/Info.plist
+++ b/iOSVouchedWebview/Info.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSCameraUsageDescription</key>
+	<string>Allow camera access to perform identity verification</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/iOSVouchedWebview/SceneDelegate.swift
+++ b/iOSVouchedWebview/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  iOSVouchedWebview
+//
+//  Created by Jay Lorenzo on 4/18/22.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/iOSVouchedWebview/ViewController.swift
+++ b/iOSVouchedWebview/ViewController.swift
@@ -1,0 +1,51 @@
+//
+//  ViewController.swift
+//  iOSVouchedWebview
+//
+//  Created by Jay Lorenzo on 4/18/22.
+//
+
+import UIKit
+import WebKit
+
+class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler {
+    
+    var webView: WKWebView!
+    // adjust the url and app public key to point to your instance
+    static let appKey: String = "YOUR_APP_KEY_HERE"
+    let appUrl: String =  "https://static.vouched.id/widget/demo/index.html#/demo?recognizeIDThreshold=0.81&cardIDThreshold=0.2&generalThreshold=0.9&glareQualityThreshold=0.6&qualityThreshold=0.6&selfieThreshold=0&holdSteadyIntervalFace=1250&detectorRunFrameInterval=2&stepTitles%5BFrontId%5D=Upload%20ID&stepTitles%5BFace%5D=Upload%20Headshot&stepTitles%5BDone%5D=Finished&stepTitles%5BID_Captured%5D=ID%20Captured&stepTitles%5BFace_Captured%5D=Face%20Captured&stepTitles%5BStart%5D=Start&stepTitles%5BBackId%5D=ID%20%28Back%29&content%5BcrossDeviceShowOff%5D=true&showUploadFirst=true&showProgressBar=true&appId=\(appKey)&testingUri=https%3A%2F%2Fverify.vouched.id%2F&crossDeviceQRCode=false&crossDeviceHandoff=false&crossDevice=false&crossDeviceSMS=false&id=both&face=both&liveness=straight&enableEyeCheck=false&debug=true&showFPS=false&sandbox=false&theme%5Bname%5D=verbose&theme%5Bfont%5D=Arial%2C%20Helvetica%2C%20sans-serif&theme%5BfontColor%5D=%23333&theme%5BiconLabelColor%5D=%23333&theme%5BbgColor%5D=%23FFF&theme%5BbaseColor%5D=%232E159F&theme%5BnavigationDisabledBackground%5D=rgba%28203%2C%20203%2C%20203%2C%200.15%29&theme%5BnavigationDisabledText%5D=%23888&theme%5BbaseColorLight%5D=rgb%28232%2C244%2C252%29&theme%5BprogressIndicatorTextColor%5D=%23000&type=id&survey=true&includeBackId=true&includeBarcode=true&disableCssBaseline=false&showTermsAndPrivacy=false&maxRetriesBeforeNext=0&idShowNext=0&handoffView%5BonlyShowQRCode%5D=false&locale=en&userConfirmation%5BconfirmData%5D=false&userConfirmation%5BconfirmImages%5D=false&isStage=true&manualCaptureTimeout=35000"
+    
+    override func loadView() {
+        let config = WKWebViewConfiguration()
+        config.allowsInlineMediaPlayback = true
+        
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+
+        view = webView
+        
+        // optional: inject JS to capture console.log output for debugging needs.
+        // Alternatively, use Safari on your development system to view output,
+        // by attaching to your ios device when running
+        let jsLoggingSrc = "function captureLog(msg) { window.webkit.messageHandlers.logHandler.postMessage(msg); } window.console.log = captureLog;"
+        let logScript = WKUserScript(source: jsLoggingSrc, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
+        
+        webView.configuration.userContentController.addUserScript(logScript)
+        webView.configuration.userContentController.add(self, name: "logHandler")
+    }
+    
+    override func viewDidLoad() {
+        let url = URL(string: appUrl)!
+        webView.load(URLRequest(url: url))
+    }
+    
+    // optional, implements WKScriptMessageHandler to see debug output
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name == "logHandler" {
+            print("Vouched Webview: \(message.body)")
+        }
+    }
+
+
+}
+

--- a/iOSVouchedWebview/camera.js
+++ b/iOSVouchedWebview/camera.js
@@ -1,0 +1,16 @@
+//injects this into webpage to listen to the camera request
+
+(function() {
+
+  if (!window.navigator) window.navigator = {};
+
+    //if getuserMedia is called -> If the user requests native camera
+
+        window.navigator.getUserMedia = function() {
+
+            webkit.messageHandlers.callbackHandler.postMessage(arguments);
+
+  }
+
+})();
+

--- a/iOSVouchedWebviewTests/iOSVouchedWebviewTests.swift
+++ b/iOSVouchedWebviewTests/iOSVouchedWebviewTests.swift
@@ -1,0 +1,36 @@
+//
+//  iOSVouchedWebviewTests.swift
+//  iOSVouchedWebviewTests
+//
+//  Created by Jay Lorenzo on 4/18/22.
+//
+
+import XCTest
+@testable import iOSVouchedWebview
+
+class iOSVouchedWebviewTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/iOSVouchedWebviewUITests/iOSVouchedWebviewUITests.swift
+++ b/iOSVouchedWebviewUITests/iOSVouchedWebviewUITests.swift
@@ -1,0 +1,42 @@
+//
+//  iOSVouchedWebviewUITests.swift
+//  iOSVouchedWebviewUITests
+//
+//  Created by Jay Lorenzo on 4/18/22.
+//
+
+import XCTest
+
+class iOSVouchedWebviewUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/iOSVouchedWebviewUITests/iOSVouchedWebviewUITestsLaunchTests.swift
+++ b/iOSVouchedWebviewUITests/iOSVouchedWebviewUITestsLaunchTests.swift
@@ -1,0 +1,32 @@
+//
+//  iOSVouchedWebviewUITestsLaunchTests.swift
+//  iOSVouchedWebviewUITests
+//
+//  Created by Jay Lorenzo on 4/18/22.
+//
+
+import XCTest
+
+class iOSVouchedWebviewUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
An example app that shows customers how to run a WKWebView container within a native iOS application, hosting the JS Plugin. This is not meant to be a product, rather just a complete example, so that customers can see how to embed the plugin in their app.

### Overview
A WKWebView is a limited subset of Safari, which allows a native iOS app to view a web page/app. Currently, it requires iOS 14.3 or higher to run, although a subsequent version will inject the necessary JS shim (camera.js) to hopefully allow camera discovery in earlier versions of iOS. The initial release is meant as a baseline.

### Required 
A public key for the plugin to test with. You can add this key to the ViewController.swift file, replacing the String "YOUR_APP_KEY_HERE" with your key.

### Testing
Use an iOS device 14.3 and newer, tethered by a USB cable with XCode (Mac only) Upon a successful build, you should be able to run an ID verification flow. The current demo url included will just run ID extraction, not face detection, just to keep the plugin URL somewhat truncated.

You should expect to see camera views for both front and back of the ID, using the existing detection models used in the plugin, eventually resulting in a successful flow.