### PR TITLE
Integration doc for ios webview

### DIFF
--- a/WebviewQuickstart.md
+++ b/WebviewQuickstart.md
@@ -170,6 +170,59 @@ class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHan
 }
 ```
 
+### Example JS Plugin for mobile testing
+
+```javascript
+<html>
+<head>
+  <!-- utf-8 is required for JS Plugin default fonts -->
+  <meta charset="utf-8" />
+  <meta name=“viewport” content=“width=device-width, initial-scale=1.0">
+  <script src="https://static.vouched.id/widget/vouched-2.0.0.js"></script>
+  <script type='text/javascript'>
+
+    (function() {
+      var vouched = Vouched({
+      // Optional verification properties.
+        verification: {
+        },
+        liveness: 'straight',
+
+        appId: '<PUBLIC_KEY_HERE>',
+       // your webhook for POST verification processing
+       // callbackURL: 'https://website.com/webhook',
+
+        // mobile handoff
+        crossDevice: false,
+        crossDeviceQRCode: false,
+        crossDeviceSMS: false,
+
+        // called when the verification is completed.
+        onDone: (job) => {
+          // token used to query jobs
+          console.log("Verification complete", { token: job.token });
+          //VouchedJS.onVerifyResults(job.result.success === true, JSON.stringify(job));
+          window.webkit.messageHandlers.onVouchedVerify.postMessage(JSON.stringify(job));
+        },
+
+        // theme
+        theme: {
+          name: 'avant',
+        },
+      });
+      vouched.mount("#vouched-element");
+    })();
+
+  </script>
+</head>
+<body>
+  <div id='vouched-element' style="height: 100%"/>
+</body>
+</html>
+```
+
+
+
 ### Other integration considerations
 
 Not discussed in this document is the notion of sharing one plugin configuration with multiple platforms, ie a configuration to cover Android WebView, iOS WKWebView, mobile browser applications, etc. One potential strategy to employ here is to test for the existence of the callback functions for each target, and if it exists, return the data, otherwise, move on to the next target.

--- a/WebviewQuickstart.md
+++ b/WebviewQuickstart.md
@@ -1,0 +1,176 @@
+# Vouched WebView (iOS) Quickstart
+
+Vouched Webview allows you to integrate with a Vouch enabled web application, and use it as a means of user verification within your moblile application, using native Android components (WKWebview).
+
+### Building the Demo
+
+We include a demo, that will allow you to quickly run a simple ID check to verify functionality. If you have a Vouched account and Xcode installed on your computer, you can quickly get the demo application up and running by cloning the repository:
+
+```shell
+git clone https://github.com/vouched/vouched-ios-webview
+cd vouched-ios-webview
+```
+
+Once you have the repository downloaded, open the project in XCode, and modify the ```ViewController``` to add your app key (if using the demo url), or change the URL to your existing Vouched endpoint.
+
+Attach a iPhone, and run the application. A ID verification flow, using the JSPlugin should appear and run. 
+
+
+### Webview Integration with the Vouched JS-Plugin
+
+In iOS we import and use the ```Webkit``` components to render pages of a web application, specifically by using the ```WKWebView``` component. Most integrations will likely integrate with a page hosting the Vouched JS Plugin, which will be the intended focus of this document. If you haven't yet configured your web application to use the plugin, take a look at our [JS Plugin quickstart guide](https://docs.vouched.id/docs/js-plugin) to get started, we will want to make some modifications to that script to allow sharing data between the hosted web application and the webview. 
+
+#### Camera access
+
+To allow web view access to device cameras, it is necessary for the user to give permission for the camera to be accessed. In your applications ```Info.plist``` be sure to include ```NSCameraUsageDescription``` to let the user know the reason why the camera is being used. This user permission is necessary the first time the application runs:
+
+```
+<key>NSCameraUsageDescription</key>
+<string>Allow camera access to perform identity verification</string>
+```
+
+In recent iOS versions, access to cameras through a webview is permitted, assuming the user gives permission. While there are no additional permissions, there is an important addition to the webview - we need to modify its configuration to allow the camera to play inline, otherwise we wind up with a camera window that doesn't display video. We can set that up in a webview configuration in ```loadView()``` like so (the assumtion here is there is a class variable :
+```
+        let config = WKWebViewConfiguration()
+      
+        config.allowsInlineMediaPlayback = true
+        
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+        
+        view = webView
+```
+
+#### Sharing verification results
+
+In mobile applications that use both web application content and native code, it is useful for the web application (running the JS Plugin) to be able to share information with the native application, say for changing behavior or navigation based on what occured in the verification flow. 
+
+In iOS, we need to inject a javascript handler to allow the web application to post messages back to the webview. In our case, we will label that handler "onVouchedVerify" which is assigned to a variable named ```vouchedHandler``` , and then added it to our webview configuration:
+
+```kotlin
+        config.userContentController.add(self, name: vouchedHandler)
+```
+
+The implied contract here is that the web application code will post a message using that handler, which the webview will intercept, and act on. In the web application, we would post that message in the JS Plugin ```onDone``` callback. Given the JS Plugin example we referenced earlier, the onDone callback would look like this:
+
+```javascript
+// called by the JS Plugin when the verification is completed.
+onDone: (job) => {
+  console.log("Verification complete", { token: job.token });
+  window.webkit.messageHandlers.onVouchedVerify.postMessage(JSON.stringify(job));
+},
+```
+
+Since the WKWebView only allows a string to be passed in a Javascript bridge, in the script above, we pass the entire results of the job in back, but you can pass whatever subset of information that makes most sense for your applications interoperability.
+
+We can listen for these messages in a ```WKScriptMessageHandler``` which looks like this:
+
+```  swift
+
+func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name == vouchedHandler {
+            
+            guard let verifyData =
+                    convertResponseToDict(payload: message.body as! String),
+                  let results = verifyData["result"] as? [String: AnyObject],
+                  let successCode = results["success"] as? Bool  else {
+                print("Unable to process verification result")
+                return
+            }
+            // todo: navigate according to success code, and/or results
+            print("User was successfully verified: \(successCode)")
+            print(results)
+        }
+    }
+```
+
+Since we are passing the entire verification payload as a string, we also add a utility function to turn it into a generic dictionary:
+
+```swift
+func convertResponseToDict(payload: String) -> [String:AnyObject]? {
+        if let data = payload.data(using: .utf8) {
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String:AnyObject]
+                return json
+            } catch {
+                print("Unable to convert verification response")
+            }
+        }
+        return nil
+    }
+```
+
+### Example UIViewController
+
+Here's a example view controller for reference that hosts a webview. Note that the appUrl should be changed to point to your endpoint, where the JS Plugin is installed and configured.
+
+```swift
+import UIKit
+import WebKit
+
+class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler {
+    
+    // the handler name injected into the web app for iOS webviews.
+    let vouchedHandler = "onVouchedVerify"
+    var webView: WKWebView!
+    // change the url to point to your instance
+    let appUrl = "https://08cc-71-212-138-132.ngrok.io"
+    
+    override func loadView() {
+        let config = WKWebViewConfiguration()
+        
+        config.userContentController.add(self, name: vouchedHandler)
+        config.allowsInlineMediaPlayback = true
+        
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+        
+        view = webView
+
+    }
+    
+    override func viewDidLoad() {
+        let url = URL(string: appUrl)!
+        webView.load(URLRequest(url: url))
+    }
+    
+    // implements WKScriptMessageHandler. For our callback, we will look
+    // for messages sent by the vouchedHandler, and operate on them
+    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+        if message.name == vouchedHandler {
+            
+            guard let verifyData =
+                    convertResponseToDict(payload: message.body as! String),
+                  let results = verifyData["result"] as? [String: AnyObject],
+                  let successCode = results["success"] as? Bool  else {
+                print("Unable to process verification result")
+                return
+            }
+            // todo: navigate according to success code, and/or results
+            print("User was successfully verified: \(successCode)")
+            print(results)
+        }
+    }
+    
+    // if using the iOS SDK, you can decode the payload into SDK objects,
+    // but given we are bridging between two platforms, we'll create a
+    // generic dictionary from the payload
+    func convertResponseToDict(payload: String) -> [String:AnyObject]? {
+        if let data = payload.data(using: .utf8) {
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String:AnyObject]
+                return json
+            } catch {
+                print("Unable to convert verification response")
+            }
+        }
+        return nil
+    }
+
+}
+```
+
+### Other integration considerations
+
+Not discussed in this document is the notion of sharing one plugin configuration with multiple platforms, ie a configuration to cover Android WebView, iOS WKWebView, mobile browser applications, etc. One potential strategy to employ here is to test for the existence of the callback functions for each target, and if it exists, return the data, otherwise, move on to the next target.
+

--- a/iOSVouchedWebview.xcodeproj/project.pbxproj
+++ b/iOSVouchedWebview.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		EC0DBAD02822F79E00F20B0B /* Settings.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = EC0DBACF2822F79E00F20B0B /* Settings.xcconfig */; };
 		ECEBBC5B280E3835005F9BCC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBBC5A280E3835005F9BCC /* AppDelegate.swift */; };
 		ECEBBC5D280E3835005F9BCC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBBC5C280E3835005F9BCC /* SceneDelegate.swift */; };
 		ECEBBC5F280E3835005F9BCC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEBBC5E280E3835005F9BCC /* ViewController.swift */; };
@@ -37,6 +38,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		EC0DBACF2822F79E00F20B0B /* Settings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Settings.xcconfig; sourceTree = "<group>"; };
 		ECEBBC57280E3835005F9BCC /* iOSVouchedWebview.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSVouchedWebview.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ECEBBC5A280E3835005F9BCC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		ECEBBC5C280E3835005F9BCC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -81,6 +83,7 @@
 		ECEBBC4E280E3835005F9BCC = {
 			isa = PBXGroup;
 			children = (
+				EC0DBACF2822F79E00F20B0B /* Settings.xcconfig */,
 				ECEBBC59280E3835005F9BCC /* iOSVouchedWebview */,
 				ECEBBC70280E3837005F9BCC /* iOSVouchedWebviewTests */,
 				ECEBBC7A280E3837005F9BCC /* iOSVouchedWebviewUITests */,
@@ -236,6 +239,7 @@
 			files = (
 				ECEBBC67280E3837005F9BCC /* LaunchScreen.storyboard in Resources */,
 				ECEBBC8B280E39F6005F9BCC /* camera.js in Resources */,
+				EC0DBAD02822F79E00F20B0B /* Settings.xcconfig in Resources */,
 				ECEBBC64280E3837005F9BCC /* Assets.xcassets in Resources */,
 				ECEBBC62280E3835005F9BCC /* Main.storyboard in Resources */,
 			);
@@ -322,6 +326,7 @@
 /* Begin XCBuildConfiguration section */
 		ECEBBC7F280E3837005F9BCC /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EC0DBACF2822F79E00F20B0B /* Settings.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -383,6 +388,7 @@
 		};
 		ECEBBC80280E3837005F9BCC /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = EC0DBACF2822F79E00F20B0B /* Settings.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -443,7 +449,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 7PKK3DW985;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOSVouchedWebview/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -471,7 +477,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 7PKK3DW985;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iOSVouchedWebview/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/iOSVouchedWebview/Base.lproj/Main.storyboard
+++ b/iOSVouchedWebview/Base.lproj/Main.storyboard
@@ -1,24 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="iOSVouchedWebview" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="20" y="60"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/iOSVouchedWebview/ViewController.swift
+++ b/iOSVouchedWebview/ViewController.swift
@@ -10,28 +10,23 @@ import WebKit
 
 class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHandler {
     
+    // the handler name injected into the web app for iOS webviews.
+    let vouchedHandler = "onVouchedVerify"
     var webView: WKWebView!
-    // adjust the url and app public key to point to your instance
-    static let appKey: String = "YOUR_APP_KEY_HERE"
-    let appUrl: String =  "https://static.vouched.id/widget/demo/index.html#/demo?recognizeIDThreshold=0.81&cardIDThreshold=0.2&generalThreshold=0.9&glareQualityThreshold=0.6&qualityThreshold=0.6&selfieThreshold=0&holdSteadyIntervalFace=1250&detectorRunFrameInterval=2&stepTitles%5BFrontId%5D=Upload%20ID&stepTitles%5BFace%5D=Upload%20Headshot&stepTitles%5BDone%5D=Finished&stepTitles%5BID_Captured%5D=ID%20Captured&stepTitles%5BFace_Captured%5D=Face%20Captured&stepTitles%5BStart%5D=Start&stepTitles%5BBackId%5D=ID%20%28Back%29&content%5BcrossDeviceShowOff%5D=true&showUploadFirst=true&showProgressBar=true&appId=\(appKey)&testingUri=https%3A%2F%2Fverify.vouched.id%2F&crossDeviceQRCode=false&crossDeviceHandoff=false&crossDevice=false&crossDeviceSMS=false&id=both&face=both&liveness=straight&enableEyeCheck=false&debug=true&showFPS=false&sandbox=false&theme%5Bname%5D=verbose&theme%5Bfont%5D=Arial%2C%20Helvetica%2C%20sans-serif&theme%5BfontColor%5D=%23333&theme%5BiconLabelColor%5D=%23333&theme%5BbgColor%5D=%23FFF&theme%5BbaseColor%5D=%232E159F&theme%5BnavigationDisabledBackground%5D=rgba%28203%2C%20203%2C%20203%2C%200.15%29&theme%5BnavigationDisabledText%5D=%23888&theme%5BbaseColorLight%5D=rgb%28232%2C244%2C252%29&theme%5BprogressIndicatorTextColor%5D=%23000&type=id&survey=true&includeBackId=true&includeBarcode=true&disableCssBaseline=false&showTermsAndPrivacy=false&maxRetriesBeforeNext=0&idShowNext=0&handoffView%5BonlyShowQRCode%5D=false&locale=en&userConfirmation%5BconfirmData%5D=false&userConfirmation%5BconfirmImages%5D=false&isStage=true&manualCaptureTimeout=35000"
+    // adjust the url and/or app public key to point to your instance
+    let appUrl = "https://08cc-71-212-138-132.ngrok.io"
     
     override func loadView() {
         let config = WKWebViewConfiguration()
+        
+        config.userContentController.add(self, name: vouchedHandler)
         config.allowsInlineMediaPlayback = true
         
         webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = self
-
+        
         view = webView
-        
-        // optional: inject JS to capture console.log output for debugging needs.
-        // Alternatively, use Safari on your development system to view output,
-        // by attaching to your ios device when running
-        let jsLoggingSrc = "function captureLog(msg) { window.webkit.messageHandlers.logHandler.postMessage(msg); } window.console.log = captureLog;"
-        let logScript = WKUserScript(source: jsLoggingSrc, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
-        
-        webView.configuration.userContentController.addUserScript(logScript)
-        webView.configuration.userContentController.add(self, name: "logHandler")
+
     }
     
     override func viewDidLoad() {
@@ -39,13 +34,39 @@ class ViewController: UIViewController, WKNavigationDelegate, WKScriptMessageHan
         webView.load(URLRequest(url: url))
     }
     
-    // optional, implements WKScriptMessageHandler to see debug output
+    // implements WKScriptMessageHandler. For our callback, we will look
+    // for messages sent by the vouchedHandler, and operate on them
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        if message.name == "logHandler" {
-            print("Vouched Webview: \(message.body)")
+        if message.name == vouchedHandler {
+            
+            guard let verifyData =
+                    convertResponseToDict(payload: message.body as! String),
+                  let results = verifyData["result"] as? [String: AnyObject],
+                  let successCode = results["success"] as? Bool  else {
+                print("Unable to process verification result")
+                return
+            }
+            // todo: navigate according to success code, and/or results
+            print("User was successfully verified: \(successCode)")
+            print(results)
         }
     }
-
+    
+    // if using the iOS SDK, you can decode the payload into SDK objects,
+    // but given we are bridging between two platforms, we'll create a
+    // generic dictionary from the payload
+    func convertResponseToDict(payload: String) -> [String:AnyObject]? {
+        if let data = payload.data(using: .utf8) {
+            do {
+                let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String:AnyObject]
+                return json
+            } catch {
+                print("Unable to convert verification response")
+            }
+        }
+        return nil
+    }
 
 }
+
 


### PR DESCRIPTION
So some context here:
Two customers of ours wants to bypass the mobile SDKs, as they feel they are too low level, so ideally, they want to essentially host the JS Plugin in a webview. In response to that, we supplied modified the JS Plugin, and provided demos that show how to run the flow in a webview

This PR is part of step two - now that the plugin and webviews are somewhat working together, provide an integration guide so that customers can get the webview and the plugin to communicate. The goal of the this review is to verify the information provided is sufficient for a mobile developer to understand how to integrate a verification flow

So here's what I'd propose for testing this PR:
- Install XCode and find an iOS Phone.
- Using the demo section of the quickstart, verify that you can build the project
- Modifying the code (ie the UIViewController class), by using a app key (public key), verify that with an iPhone attached, you are able to scan an ID successfully
